### PR TITLE
also log error code if babeld_handle_in() fails

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -422,7 +422,7 @@ void loop(struct context *ctx) {
 				} else if (events[i].events & EPOLLIN) {
 					int babelhandle_status = babeld_handle_in(ctx, events[i].data.fd);
 					if ( babelhandle_status < 0 ) {
-						printf("babeld_handle_in was not successful - reconnecting\n");
+						printf("babeld_handle_in was not successful (status %d) - reconnecting\n", babelhandle_status);
 						reconnect_babeld(ctx);
 					} else if ( babelhandle_status == 0 ) {
 						log_debug(ctx, "waiting for more data to appear on babel socket.\n");


### PR DESCRIPTION
I'm seeing these messages ("babeld_handle_in was not successful - reconnecting") on some devices and would like to know what exactly causes them, so the exact error code might be useful.

I have compiled this change successfully, but have not tested it at all.