### PR TITLE
main: use proper format strings when logging uint32_t/ssize_t

### DIFF
--- a/src/intercom.c
+++ b/src/intercom.c
@@ -115,7 +115,7 @@ void intercom_send_packet_allif(struct context *ctx, uint8_t *packet, ssize_t pa
 	for (size_t i = 0; i < VECTOR_LEN(ctx->interfaces); i++) {
 		interface *iface = &VECTOR_INDEX(ctx->interfaces, i);
 		ctx->groupaddr.sin6_scope_id = iface->ifindex;
-		ssize_t rc = sendto(ctx->intercomfd, packet, packet_len, 0, &ctx->groupaddr, sizeof(struct sockaddr_in6));
+		ssize_t rc = sendto(ctx->intercomfd, packet, packet_len, 0, (struct sockaddr*)&ctx->groupaddr, sizeof(struct sockaddr_in6));
 		if (rc < 0)
 			perror("sendto");
 		log_debug("sent intercom packet on %s to %s rc: %zi\n", iface->ifname, print_ip(&ctx->groupaddr.sin6_addr), rc);

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -92,10 +92,6 @@ bool if_add(char *ifname) {
 		return true;
 	}
 
-	if (setsockopt(ctx.intercomfd, SOL_SOCKET, SO_BINDTODEVICE, iface.ifname, strnlen(iface.ifname, IFNAMSIZ))) {
-		exit_error("error on setsockopt (BIND)");
-	}
-
 	return false;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -189,9 +189,10 @@ bool forward_packet(struct context *ctx, uint8_t *packet, ssize_t len, uint64_t 
 				.msg_iovlen = 2,
 			};
 
-			log_verbose("Forwarding packet from %s with destaddr=%s, nonce=" FMT_NONCE " to %s%%%s [%d].\n",
+			log_verbose("Forwarding packet from %s with destaddr=%s, nonce=" FMT_NONCE " to %s%%%s [%zd].\n",
 				    src_addr ? print_ip(&src_addr->sin6_addr) : "local", print_ip(&packethdr->daddr), nonce,
 				    print_ip(&neighbour->address.sin6_addr), neighbour->ifname, neighbour->address.sin6_scope_id);
+
 			if (sendmsg(ctx->intercomfd, &msg, 0) < 0)
 				perror("sendmsg");
 		}
@@ -226,7 +227,7 @@ void udp_handle_in(struct context *ctx, int fd) {
 		};
 
 		ssize_t count = recvmsg(fd, &message, 0);
-		log_debug("read %lld bytes\n", count);
+		log_debug("read %zd bytes\n", count);
 
 		if (count == -1 && errno == EAGAIN)
 			break;

--- a/src/mmfd.h
+++ b/src/mmfd.h
@@ -12,7 +12,7 @@
 
 #define PORT 27275
 #define HELLO_INTERVAL 10
-#define FMT_NONCE "0x%08x"
+#define FMT_NONCE "0x%08"PRIx64
 
 typedef struct interface {
 	char ifname[IFNAMSIZ];


### PR DESCRIPTION
this should fix a crash when forwarding packets while in verbose mode.